### PR TITLE
Allow decimal text label sizes

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -564,7 +564,7 @@ function showTextForm(latlng) {
       return;
     }
     var description = document.getElementById('text-label-description').value || '';
-    var size = parseInt(document.getElementById('text-label-size').value, 10) || 14;
+    var size = parseFloat(document.getElementById('text-label-size').value) || 14;
     var angle = parseFloat(document.getElementById('text-label-angle').value) || 0;
     var spacing = parseFloat(document.getElementById('text-letter-spacing').value) || 0;
     var curve = parseFloat(document.getElementById('text-curve-radius').value) || 0;
@@ -626,7 +626,7 @@ function editTextForm(labelMarker) {
       return;
     }
     var description = document.getElementById('text-label-description').value || '';
-    var size = parseInt(document.getElementById('text-label-size').value, 10) || 14;
+    var size = parseFloat(document.getElementById('text-label-size').value) || 14;
     var angle = parseFloat(document.getElementById('text-label-angle').value) || 0;
     var spacing = parseFloat(document.getElementById('text-letter-spacing').value) || 0;
     var curve = parseFloat(document.getElementById('text-curve-radius').value) || 0;


### PR DESCRIPTION
## Summary
- use parseFloat instead of parseInt when reading text label size so decimal font sizes are preserved

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "const val=parseFloat('0.5') || 14; console.log(val);"`


------
https://chatgpt.com/codex/tasks/task_e_68b94e14fad4832ea3e1d4273a9df26c