### PR TITLE
Add fishing icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
                     <option value="settlement">Settlement</option>
                     <option value="sachemdom">Sachemdom</option>
                     <option value="trading">Trading</option>
+                    <option value="fishing">Fishing</option>
                 </select>
             </label>
             <button id="marker-save">Save</button>

--- a/js/map.js
+++ b/js/map.js
@@ -78,6 +78,18 @@ map.on('click', function () {
                 popupAnchor: [0.125, -1.25],
                 tooltipAnchor: [0.625, -0.625]
         });
+  // Fishing
+  var fishingIconPath =
+    'icons/' +
+    'commonwealth_7h14b159j_productionMaster25.psb_0000s_0029_Fish_icon_(The_Noun_Project_27052).svg.png';
+  var FishingIcon = L.icon({
+                iconUrl:       fishingIconPath,
+                iconRetinaUrl: fishingIconPath,
+                iconSize:    [1.25, 1.25],
+                iconAnchor:  [0.625, 1.25],
+                popupAnchor: [0.125, -1.25],
+                tooltipAnchor: [0.625, -0.625]
+        });
 
 
 // Map of icon keys to actual icons
@@ -86,6 +98,7 @@ var iconMap = {
   settlement: SettlementsIcon,
   sachemdom: SachemdomsIcon,
   trading: TradingIcon,
+  fishing: FishingIcon,
 };
 
 // Store custom marker data and marker instances


### PR DESCRIPTION
## Summary
- Register fishing marker icon using existing fish image
- Expose Fishing as a selectable marker type
- Remove Fish.png asset from repository

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b94b8635e8832e807f3aa87a71b048