### PR TITLE
Fix fishing icon aspect ratio

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -83,10 +83,11 @@ map.on('click', function () {
   var FishingIcon = L.icon({
                 iconUrl:       fishingIconPath,
                 iconRetinaUrl: fishingIconPath,
-                iconSize:    [1.25, 1.25],
-                iconAnchor:  [0.625, 1.25],
+                // Preserve the original aspect ratio of the fish icon (25x11)
+                iconSize:    [2.84, 1.25],
+                iconAnchor:  [1.42, 1.25],
                 popupAnchor: [0.125, -1.25],
-                tooltipAnchor: [0.625, -0.625]
+                tooltipAnchor: [1.42, -0.625]
         });
 
 


### PR DESCRIPTION
## Summary
- preserve fish icon aspect ratio by widening icon and adjusting anchor points

## Testing
- `node --check js/map.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b956c84610832ebe9bab8794e28cf5