### PR TITLE
Persist dragged base text labels

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -354,6 +354,14 @@ function addTextLabelToMap(data) {
         var pos = m.getLatLng();
         m._data.lat = pos.lat;
         m._data.lng = pos.lng;
+        var idx = customTextLabels.findIndex(function (t) {
+          return t.text === m._data.text;
+        });
+        if (idx !== -1) {
+          customTextLabels[idx] = m._data;
+        } else {
+          customTextLabels.push(m._data);
+        }
         saveTextLabels();
       }
     })
@@ -393,18 +401,6 @@ var stored = localStorage.getItem('markers');
 if (stored) {
   customMarkers = JSON.parse(stored);
   customMarkers.forEach(addMarkerToMap);
-}
-
-var storedTexts = localStorage.getItem('textLabels');
-if (storedTexts) {
-  customTextLabels = JSON.parse(storedTexts);
-  customTextLabels.forEach(addTextLabelToMap);
-}
-
-var storedPolygons = localStorage.getItem('polygons');
-if (storedPolygons) {
-  customPolygons = JSON.parse(storedPolygons);
-  customPolygons.forEach(addPolygonToMap);
 }
 
 var baseTextLabels = [
@@ -466,7 +462,30 @@ var baseTextLabels = [
     size: 24,
   },
 ];
+
+var storedTexts = localStorage.getItem('textLabels');
+if (storedTexts) {
+  customTextLabels = JSON.parse(storedTexts);
+  customTextLabels.forEach(function (t) {
+    var idx = baseTextLabels.findIndex(function (b) {
+      return b.text === t.text;
+    });
+    if (idx !== -1) {
+      baseTextLabels[idx] = t;
+    } else {
+      baseTextLabels.push(t);
+    }
+  });
+} else {
+  customTextLabels = [];
+}
 baseTextLabels.forEach(addTextLabelToMap);
+
+var storedPolygons = localStorage.getItem('polygons');
+if (storedPolygons) {
+  customPolygons = JSON.parse(storedPolygons);
+  customPolygons.forEach(addPolygonToMap);
+}
 
 var baseTerritories = [
   {


### PR DESCRIPTION
## Summary
- Track text label drags by inserting or updating entries in `customTextLabels`
- Merge stored text labels with base defaults on load, letting stored entries override
- Confirm text label persistence via `saveTextLabels` using `localStorage`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4b2b8468832e9826f9d5095cb059