### PR TITLE
Load map markers and labels from CSV

### DIFF
--- a/data/map-data.csv
+++ b/data/map-data.csv
@@ -1,0 +1,3 @@
+lat,lng,name,description,iconKey,text,fontSize,angle,spacing,curve
+36.0135,-106.3916,Gulndar,A small but bustling town.,settlement,,,,
+42.5,-72.7,,,,Pocomtuc Confederacy,24,,,

--- a/js/map.js
+++ b/js/map.js
@@ -164,6 +164,53 @@ var baseZoom;
 var selectedMarker = null;
 var territoriesLayer = L.layerGroup().addTo(map);
 
+// Load marker and text label data from a CSV file
+function loadDataFromCsv(url) {
+  return fetch(url)
+    .then(function (response) {
+      return response.text();
+    })
+    .then(function (csv) {
+      var lines = csv.trim().split(/\r?\n/);
+      var headers = lines.shift().split(',');
+      var markers = [];
+      var labels = [];
+      lines.forEach(function (line) {
+        if (!line.trim()) return;
+        var cols = line.split(',');
+        var row = {};
+        headers.forEach(function (h, i) {
+          row[h] = cols[i] ? cols[i].trim() : '';
+        });
+        var lat = parseFloat(row.lat);
+        var lng = parseFloat(row.lng);
+        if (isNaN(lat) || isNaN(lng)) return;
+        if (row.name) {
+          markers.push({
+            lat: lat,
+            lng: lng,
+            name: row.name,
+            description: row.description || '',
+            icon: row.iconKey || 'wigwam',
+          });
+        }
+        if (row.text) {
+          labels.push({
+            lat: lat,
+            lng: lng,
+            text: row.text,
+            description: row.description || '',
+            size: parseFloat(row.fontSize) || 24,
+            angle: parseFloat(row.angle) || 0,
+            spacing: parseFloat(row.spacing) || 0,
+            curve: parseFloat(row.curve) || 0,
+          });
+        }
+      });
+      return { markers: markers, labels: labels };
+    });
+}
+
 function clearSelectedMarker() {
   if (selectedMarker && selectedMarker._icon) {
     selectedMarker._icon.classList.remove('marker-selected');
@@ -272,7 +319,7 @@ function addMarkerToMap(data) {
     icon,
     data.name,
     data.description
-  ).addTo(map);
+  ).addTo(Settlements);
   customMarker._data = data;
   customMarker.on('contextmenu', function () {
     map.removeLayer(customMarker);
@@ -396,90 +443,13 @@ function addTextLabelToMap(data) {
   rescaleTextLabels();
 }
 
-// Load markers from localStorage
-var stored = localStorage.getItem('markers');
-if (stored) {
-  customMarkers = JSON.parse(stored);
+// Load markers and text labels from CSV
+loadDataFromCsv('data/map-data.csv').then(function (result) {
+  customMarkers = result.markers || [];
   customMarkers.forEach(addMarkerToMap);
-}
-
-var baseTextLabels = [
-  {
-    lat: 42.5,
-    lng: -72.7,
-    text: 'Pocomtuc Confederacy',
-    description: '',
-    size: 24,
-  },
-  {
-    lat: 42.2,
-    lng: -71.8,
-    text: 'Nipmuc',
-    description: '',
-    size: 24,
-  },
-  {
-    lat: 42.35,
-    lng: -71.0,
-    text: 'Massachusett',
-    description: '',
-    size: 24,
-  },
-  {
-    lat: 41.7,
-    lng: -70.3,
-    text: 'Wampanoag',
-    description: '',
-    size: 24,
-  },
-  {
-    lat: 41.5,
-    lng: -71.5,
-    text: 'Narragansett',
-    description: '',
-    size: 24,
-  },
-  {
-    lat: 41.7,
-    lng: -71.2,
-    text: 'Pokanoket',
-    description: '',
-    size: 24,
-  },
-  {
-    lat: 41.5,
-    lng: -69.5,
-    text: 'Weekehikum',
-    description: '',
-    size: 24,
-    angle: 90,
-  },
-  {
-    lat: 42.6,
-    lng: -70.9,
-    text: 'Agawam',
-    description: '',
-    size: 24,
-  },
-];
-
-var storedTexts = localStorage.getItem('textLabels');
-if (storedTexts) {
-  customTextLabels = JSON.parse(storedTexts);
-  customTextLabels.forEach(function (t) {
-    var idx = baseTextLabels.findIndex(function (b) {
-      return b.text === t.text;
-    });
-    if (idx !== -1) {
-      baseTextLabels[idx] = t;
-    } else {
-      baseTextLabels.push(t);
-    }
-  });
-} else {
-  customTextLabels = [];
-}
-baseTextLabels.forEach(addTextLabelToMap);
+  customTextLabels = result.labels || [];
+  customTextLabels.forEach(addTextLabelToMap);
+});
 
 var storedPolygons = localStorage.getItem('polygons');
 if (storedPolygons) {
@@ -565,32 +535,10 @@ function createMarker(lat, lng, icon, name, description) {
   return m;
 }
 
-var el_gulndar = createMarker(36.0135, -106.3916, SettlementsIcon, 'Gulndar', 'A small but bustling town.');
-//  2.Trading post markers
-
-// var el_gulndar = L.marker([36.0135, -106.3916],{icon:citiesIcon}).bindPopup('<b>Gulndar</b>');
-
-//  3. Geographical Locations MARKERS
-
-// var el_gulndar = L.marker([36.0135, -106.3916],{icon:citiesIcon}).bindPopup('<b>Gulndar</b>');
-
-//  4. Capitals MARKERS
-
-// var el_gulndar = L.marker([36.0135, -106.3916],{icon:citiesIcon}).bindPopup('<b>Gulndar</b>');
-
-//  5. Forts/Castles MARKERS
-
-// var el_gulndar = L.marker([36.0135, -106.3916],{icon:citiesIcon}).bindPopup('<b>Gulndar</b>');
-
-//  6. Temples MARKERS
-
-// var el_gulndar = L.marker([36.0135, -106.3916],{icon:citiesIcon}).bindPopup('<b>Gulndar</b>');
-
-
 // ******END OF MARKERS DECLARATION ******
 
 // MARKER GROUPS
-var Settlements = L.layerGroup([el_gulndar]).addTo(map);
+var Settlements = L.layerGroup().addTo(map);
 // Marker overlay
 var overlays= {
   // "GROUPNAME":mg_GROUPNAME


### PR DESCRIPTION
## Summary
- add `loadDataFromCsv` to fetch and parse marker and text-label data
- bootstrap map markers and labels from `data/map-data.csv` instead of localStorage
- add sample `data/map-data.csv` illustrating required columns

## Testing
- `node --check js/map.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba606f0e04832e84fbacba13123ae1