### PR TITLE
Add CSV export of map features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Map Project
+
+This project is a web-based map using Leaflet. Users can add custom markers, text labels, and polygons.
+
+## Feature Export
+
+Whenever markers, text labels, or polygons are saved, the map now generates a CSV representation and attempts to write it to `data/features.csv`. If a server endpoint at `data/features.csv` is available, the CSV is posted there to overwrite the file; otherwise a download is triggered in the browser.
+
+Each row of the CSV includes a `type` column identifying the feature (`marker`, `text`, or `polygon`) followed by relevant attributes such as coordinates, label text, and style information.
+
+The initial CSV file lives at `data/features.csv` and can be used as a template for further exports.

--- a/data/features.csv
+++ b/data/features.csv
@@ -1,0 +1,1 @@
+type,lat,lng,icon,name,text,description,size,angle,spacing,curve,coords,style

--- a/js/map.js
+++ b/js/map.js
@@ -222,16 +222,108 @@ function rescaleTextLabels() {
   });
 }
 
+function exportFeaturesToCSV() {
+  function escapeCsv(val) {
+    if (val === undefined || val === null) return '';
+    var str = String(val).replace(/"/g, '""');
+    return /[",\n]/.test(str) ? '"' + str + '"' : str;
+  }
+
+  var rows = [
+    'type,lat,lng,icon,name,text,description,size,angle,spacing,curve,coords,style'
+  ];
+
+  customMarkers.forEach(function (m) {
+    rows.push(
+      [
+        'marker',
+        escapeCsv(m.lat),
+        escapeCsv(m.lng),
+        escapeCsv(m.icon),
+        escapeCsv(m.name),
+        '',
+        escapeCsv(m.description),
+        '',
+        '',
+        '',
+        '',
+        '',
+        escapeCsv(JSON.stringify(m.style || {}))
+      ].join(',')
+    );
+  });
+
+  customTextLabels.forEach(function (t) {
+    rows.push(
+      [
+        'text',
+        escapeCsv(t.lat),
+        escapeCsv(t.lng),
+        '',
+        '',
+        escapeCsv(t.text),
+        escapeCsv(t.description),
+        escapeCsv(t.size),
+        escapeCsv(t.angle),
+        escapeCsv(t.spacing),
+        escapeCsv(t.curve),
+        '',
+        ''
+      ].join(',')
+    );
+  });
+
+  customPolygons.forEach(function (p) {
+    rows.push(
+      [
+        'polygon',
+        '',
+        '',
+        '',
+        escapeCsv(p.name),
+        '',
+        escapeCsv(p.description),
+        '',
+        '',
+        '',
+        '',
+        escapeCsv(JSON.stringify(p.coords)),
+        escapeCsv(JSON.stringify(p.style || {}))
+      ].join(',')
+    );
+  });
+
+  var csvContent = rows.join('\n');
+
+  // Try posting to a server endpoint; fall back to client-side download
+  fetch('data/features.csv', {
+    method: 'POST',
+    headers: { 'Content-Type': 'text/csv' },
+    body: csvContent
+  }).catch(function () {
+    var blob = new Blob([csvContent], { type: 'text/csv' });
+    var a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'features.csv';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  });
+}
+
 function saveMarkers() {
   localStorage.setItem('markers', JSON.stringify(customMarkers));
+  exportFeaturesToCSV();
 }
 
 function saveTextLabels() {
   localStorage.setItem('textLabels', JSON.stringify(customTextLabels));
+  exportFeaturesToCSV();
 }
 
 function savePolygons() {
   localStorage.setItem('polygons', JSON.stringify(customPolygons));
+  exportFeaturesToCSV();
 }
 
 function updateEditToolbar() {


### PR DESCRIPTION
## Summary
- add exportFeaturesToCSV to serialize markers, text labels, and polygons
- update save functions to trigger CSV export and add initial data/features.csv
- document CSV export behavior in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7e19ef70832e8c321285107c2ab4