### PR TITLE
Handle CSV export errors and add server storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,17 @@ This project is a web-based map using Leaflet. Users can add custom markers, tex
 
 ## Feature Export
 
-Whenever markers, text labels, or polygons are saved, the map now generates a CSV representation and attempts to write it to `data/features.csv`. If a server endpoint at `data/features.csv` is available, the CSV is posted there to overwrite the file; otherwise a download is triggered in the browser.
+Whenever markers, text labels, or polygons are saved, the map generates a CSV representation and tries to POST it to `data/features.csv`. If the request succeeds (HTTP 200), the file is overwritten on the server. If the request fails or returns a non-OK response, the browser falls back to downloading `features.csv` locally.
 
 Each row of the CSV includes a `type` column identifying the feature (`marker`, `text`, or `polygon`) followed by relevant attributes such as coordinates, label text, and style information.
+
+For persistent storage, run the Express server in `server/index.js`:
+
+```
+npm install express
+node server/index.js
+```
+
+The server exposes a `POST /data/features.csv` route that writes the uploaded CSV to `data/features.csv`. Without this server the CSV will only be downloaded on the client.
 
 The initial CSV file lives at `data/features.csv` and can be used as a template for further exports.

--- a/js/map.js
+++ b/js/map.js
@@ -300,15 +300,21 @@ function exportFeaturesToCSV() {
     method: 'POST',
     headers: { 'Content-Type': 'text/csv' },
     body: csvContent
-  }).catch(function () {
-    var blob = new Blob([csvContent], { type: 'text/csv' });
-    var a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = 'features.csv';
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-  });
+  })
+    .then(function (response) {
+      if (!response.ok) {
+        throw new Error('Server rejected save');
+      }
+    })
+    .catch(function () {
+      var blob = new Blob([csvContent], { type: 'text/csv' });
+      var a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'features.csv';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    });
 }
 
 function saveMarkers() {

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+
+// accept raw CSV payloads
+app.use(express.text({ type: 'text/csv' }));
+
+// Endpoint to overwrite the CSV on disk
+app.post('/data/features.csv', (req, res) => {
+  const csvPath = path.join(__dirname, '..', 'data', 'features.csv');
+  fs.writeFile(csvPath, req.body, (err) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).send('Failed to save CSV');
+    }
+    res.sendStatus(200);
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});
+


### PR DESCRIPTION
## Summary
- Add response check in `exportFeaturesToCSV` so download fallback triggers on non-OK server replies
- Provide Express server route to persist CSV to disk
- Document client/server CSV saving behavior in README

## Testing
- `node --check js/map.js`
- `node --check server/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba8b67b3a0832ea6875024732bc16e