### PR TITLE
Add mouse coordinate overlay to map

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -126,3 +126,15 @@ html, body{
     height: auto;
     display: block;
 }
+
+#mouse-coords {
+    position: fixed;
+    bottom: 10px;
+    left: 10px;
+    background: #fff;
+    padding: 4px 8px;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    z-index: 1000;
+    pointer-events: none;
+}

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 <body>
     <!-- <h1>map</h1> -->
     <div id="map"></div>
+    <div id="mouse-coords"></div>
     <div id="info-panel" class="hidden">
         <button id="close-info" class="close-button">&times;</button>
         <h2 id="info-title"></h2>

--- a/js/map.js
+++ b/js/map.js
@@ -17,6 +17,16 @@ tiles.once('load', function () {
   rescaleTextLabels();
 });
 
+var mouseCoords = document.getElementById('mouse-coords');
+
+map.on('mousemove', function (e) {
+  mouseCoords.textContent = e.latlng.lat.toFixed(4) + ', ' + e.latlng.lng.toFixed(4);
+});
+
+map.on('mouseout', function () {
+  mouseCoords.textContent = '';
+});
+
 // Remove default marker shadows
 L.Icon.Default.mergeOptions({
   shadowUrl: null,


### PR DESCRIPTION
## Summary
- show cursor coordinates in new `#mouse-coords` overlay
- style coordinate overlay with fixed positioning and map-top z-index
- update map script to display and clear coordinates on mouse movement

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4da2ddb10832e8e00238226b5af94