### PR TITLE
Add save changes control for feature export

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project is a web-based map using Leaflet. Users can add custom markers, tex
 
 ## Feature Export
 
-Whenever markers, text labels, or polygons are saved, the map generates a CSV representation and tries to POST it to `/save-features`. If the request succeeds (HTTP 200), the file is committed to the GitHub repository. If the request fails or returns a non-OK response, the browser falls back to downloading `features.csv` locally.
+Click the **Save Changes** button to generate a CSV representation of all markers, text labels, and polygons. The client tries to POST the CSV to `/save-features` and, if the request succeeds (HTTP 200), the file is committed to the GitHub repository. If the request fails or returns a non-OK response, the browser falls back to downloading `features.csv` locally.
 
 Each row of the CSV includes a `type` column identifying the feature (`marker`, `text`, or `polygon`) followed by relevant attributes such as coordinates, label text, and style information.
 

--- a/css/index.css
+++ b/css/index.css
@@ -20,6 +20,13 @@ html, body{
     z-index: 1000;
 }
 
+#save-changes {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 1000;
+}
+
 #info-title,
 #info-description {
     text-align: center;

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 <body>
     <!-- <h1>map</h1> -->
     <div id="map"></div>
+    <button id="save-changes">Save Changes</button>
     <div id="mouse-coords"></div>
     <div id="info-panel" class="hidden">
         <button id="close-info" class="close-button">&times;</button>

--- a/js/map.js
+++ b/js/map.js
@@ -403,15 +403,15 @@ function exportFeaturesToCSV() {
 }
 
 function saveMarkers() {
-  return exportFeaturesToCSV();
+  updateEditToolbar();
 }
 
 function saveTextLabels() {
-  return exportFeaturesToCSV();
+  updateEditToolbar();
 }
 
 function savePolygons() {
-  return exportFeaturesToCSV();
+  updateEditToolbar();
 }
 
 function updateEditToolbar() {
@@ -1170,5 +1170,7 @@ map.on(L.Draw.Event.DELETED, function (e) {
   updateEditToolbar();
 });
 
-
+document.getElementById('save-changes').addEventListener('click', function () {
+  exportFeaturesToCSV();
+});
 


### PR DESCRIPTION
## Summary
- Add Save Changes button so features.csv is only exported on demand
- Style button and hook it to CSV export
- Update README to document manual save workflow

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/map/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c4e974553c832ebba7b64c9d3ab915