### PR TITLE
Add sample overlay layer and control

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -17,6 +17,13 @@ tiles.once('load', function () {
   rescaleTextLabels();
 });
 
+var overlayBounds = [[-20, -20], [20, 20]];
+var sampleOverlay = L.rectangle(overlayBounds, { color: '#ff7800', weight: 1, fillOpacity: 0.2 }).addTo(map);
+
+var baseLayers = { 'Base Map': tiles };
+var overlayLayers = { 'Sample Overlay': sampleOverlay };
+L.control.layers(baseLayers, overlayLayers, { collapsed: false }).addTo(map);
+
 var mouseCoords = document.getElementById('mouse-coords');
 
 map.on('mousemove', function (e) {


### PR DESCRIPTION
## Summary
- Add sample rectangle overlay on the map.
- Provide layers control to toggle the sample overlay.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c505885bf4832ebe786ab2a1fe84bf