### PR TITLE
Enable interactive image overlay uploads

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -27,6 +27,22 @@ html, body{
     z-index: 1000;
 }
 
+#overlay-upload, #overlay-opacity-label {
+    position: absolute;
+    left: 10px;
+    z-index: 1000;
+}
+#overlay-upload {
+    top: 50px;
+}
+#overlay-opacity-label {
+    top: 80px;
+    background: #fff;
+    padding: 2px 4px;
+    border-radius: 4px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+}
+
 #info-title,
 #info-description {
     text-align: center;

--- a/index.html
+++ b/index.html
@@ -8,14 +8,20 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Open+Sans:wght@400;700&display=swap">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.distortableimage@0.18.7/dist/leaflet.distortableimage.css"/>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
+    <script src="https://unpkg.com/leaflet.distortableimage@0.18.7/dist/leaflet.distortableimage.js"></script>
      
 </head>
 <body>
     <!-- <h1>map</h1> -->
     <div id="map"></div>
     <button id="save-changes">Save Changes</button>
+    <input type="file" id="overlay-upload" accept="image/*">
+    <label for="overlay-opacity" id="overlay-opacity-label">Opacity:
+        <input type="range" id="overlay-opacity" min="0" max="1" step="0.1" value="1">
+    </label>
     <div id="mouse-coords"></div>
     <div id="info-panel" class="hidden">
         <button id="close-info" class="close-button">&times;</button>

--- a/js/map.js
+++ b/js/map.js
@@ -17,6 +17,42 @@ tiles.once('load', function () {
   rescaleTextLabels();
 });
 
+var baseLayers = { 'Base Map': tiles };
+var layerControl = L.control.layers(baseLayers, {}, { collapsed: false }).addTo(map);
+var imageOverlay = null;
+
+var uploadInput = document.getElementById('overlay-upload');
+var opacityInput = document.getElementById('overlay-opacity');
+
+uploadInput.addEventListener('change', function (e) {
+  var file = e.target.files[0];
+  if (!file) return;
+  var reader = new FileReader();
+  reader.onload = function (ev) {
+    var center = map.getCenter();
+    var offset = 5;
+    var corners = [
+      L.latLng(center.lat + offset, center.lng - offset),
+      L.latLng(center.lat + offset, center.lng + offset),
+      L.latLng(center.lat - offset, center.lng + offset),
+      L.latLng(center.lat - offset, center.lng - offset)
+    ];
+    if (imageOverlay) {
+      layerControl.removeLayer(imageOverlay);
+      map.removeLayer(imageOverlay);
+    }
+    imageOverlay = L.distortableImageOverlay(ev.target.result, { corners: corners, opacity: parseFloat(opacityInput.value) }).addTo(map);
+    imageOverlay.editing.enable();
+    layerControl.addOverlay(imageOverlay, file.name || 'Image Overlay');
+  };
+  reader.readAsDataURL(file);
+});
+
+opacityInput.addEventListener('input', function (e) {
+  var opacity = parseFloat(e.target.value);
+  if (imageOverlay) imageOverlay.setOpacity(opacity);
+});
+
 var mouseCoords = document.getElementById('mouse-coords');
 
 map.on('mousemove', function (e) {


### PR DESCRIPTION
## Summary
- Allow users to upload images as resizable, draggable overlays.
- Add opacity slider and DistortableImage plugin integration.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c505885bf4832ebe786ab2a1fe84bf