### PR TITLE
Reposition overlay controls to avoid toolbar overlap

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -29,14 +29,15 @@ html, body{
 
 #overlay-upload, #overlay-opacity-label {
     position: absolute;
-    left: 10px;
+    right: 10px;
+    left: auto;
     z-index: 1000;
 }
 #overlay-upload {
-    top: 50px;
+    top: 100px;
 }
 #overlay-opacity-label {
-    top: 80px;
+    top: 130px;
     background: #fff;
     padding: 2px 4px;
     border-radius: 4px;


### PR DESCRIPTION
## Summary
- move overlay upload and opacity controls to top-right so they no longer obstruct the map toolbar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c519bd7f74832eac574e51e4fd4abc