### PR TITLE
Add guard for missing overlay plugin

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -42,6 +42,12 @@ document.getElementById('overlay-upload').addEventListener('change', function (e
           map.removeLayer(overlayLayer);
         }
         var bounds = map.getBounds();
+        if (!L.distortableImageOverlay) {
+          const msg = 'Overlay plugin not loaded.';
+          console.error(msg);
+          overlayError.textContent = msg;
+          return;
+        }
         overlayLayer = L.distortableImageOverlay(ev.target.result, {
           corners: [
             bounds.getNorthWest(),


### PR DESCRIPTION
## Summary
- Prevent errors when Leaflet distortable image plugin is missing by logging and showing an alert.

## Testing
- ⚠️ `node test-plugin-guard.js` *(missing libatk-1.0.so.0 prevents headless browser launch)*

------
https://chatgpt.com/codex/tasks/task_e_68c542bfbe10832e8e6db91729bcc64a