### PR TITLE
Fix overlay corner order for image overlays

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -52,8 +52,8 @@ document.getElementById('overlay-upload').addEventListener('change', function (e
           corners: [
             bounds.getNorthWest(),
             bounds.getNorthEast(),
-            bounds.getSouthEast(),
             bounds.getSouthWest(),
+            bounds.getSouthEast(),
           ],
           opacity: parseFloat(document.getElementById('overlay-opacity').value),
         }).addTo(map);


### PR DESCRIPTION
## Summary
- Ensure image overlay corners are ordered NW, NE, SW, SE when creating distortable overlays

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68c553165874832e951505c512c4a452