### PR TITLE
Add size slider and enable draggable overlays

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -27,7 +27,7 @@ html, body{
     z-index: 1000;
 }
 
-#overlay-upload, #overlay-opacity-label {
+#overlay-upload, #overlay-opacity-label, #overlay-size-label {
     position: absolute;
     right: 10px;
     left: auto;
@@ -38,6 +38,11 @@ html, body{
 }
 #overlay-opacity-label {
     top: 130px;
+}
+#overlay-size-label {
+    top: 160px;
+}
+#overlay-opacity-label, #overlay-size-label {
     background: #fff;
     padding: 2px 4px;
     border-radius: 4px;
@@ -45,7 +50,7 @@ html, body{
 }
 #overlay-error {
     position: absolute;
-    top: 160px;
+    top: 190px;
     right: 10px;
     left: auto;
     z-index: 1000;

--- a/index.html
+++ b/index.html
@@ -23,6 +23,9 @@
     <label for="overlay-opacity" id="overlay-opacity-label">Opacity:
         <input type="range" id="overlay-opacity" min="0" max="1" step="0.1" value="1" aria-label="Overlay opacity">
     </label>
+    <label for="overlay-size" id="overlay-size-label">Size:
+        <input type="range" id="overlay-size" min="0.1" max="3" step="0.1" value="1" aria-label="Overlay size">
+    </label>
     <div id="mouse-coords"></div>
     <div id="info-panel" class="hidden">
         <button id="close-info" class="close-button">&times;</button>

--- a/js/map.js
+++ b/js/map.js
@@ -29,6 +29,8 @@ map.on('mouseout', function () {
 
 var overlayLayer = null;
 var overlayError = document.getElementById('overlay-error');
+var overlaySizeSlider = document.getElementById('overlay-size');
+var overlayScale = 1;
 document.getElementById('overlay-upload').addEventListener('change', function (e) {
   overlayError.textContent = '';
   var file = e.target.files[0];
@@ -57,6 +59,16 @@ document.getElementById('overlay-upload').addEventListener('change', function (e
           ],
           opacity: parseFloat(document.getElementById('overlay-opacity').value),
         }).addTo(map);
+        overlayScale = 1;
+        if (overlaySizeSlider) overlaySizeSlider.value = 1;
+        if (overlayLayer.editing) {
+          overlayLayer.editing.enable();
+        }
+        if (overlayLayer.enableDragging) {
+          overlayLayer.enableDragging();
+        } else if (overlayLayer.dragging && overlayLayer.dragging.enable) {
+          overlayLayer.dragging.enable();
+        }
       };
       img.onerror = function () {
         var msg = 'The selected file is not a valid image.';
@@ -80,6 +92,17 @@ document.getElementById('overlay-upload').addEventListener('change', function (e
 document.getElementById('overlay-opacity').addEventListener('input', function (e) {
   if (overlayLayer) {
     overlayLayer.setOpacity(parseFloat(e.target.value));
+  }
+});
+
+overlaySizeSlider.addEventListener('input', function (e) {
+  if (overlayLayer) {
+    var scale = parseFloat(e.target.value);
+    var factor = scale / overlayScale;
+    if (overlayLayer.scaleBy) {
+      overlayLayer.scaleBy(factor);
+    }
+    overlayScale = scale;
   }
 });
 


### PR DESCRIPTION
## Summary
- Add overlay size slider below opacity control
- Allow uploaded overlay images to be dragged and resized via new slider

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c559dc128c832e9ae2607aaad073b5