### PR TITLE
Preserve uploaded overlay aspect ratio and enable dragging

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -50,14 +50,25 @@ document.getElementById('overlay-upload').addEventListener('change', function (e
           overlayError.textContent = msg;
           return;
         }
+        var mapSize = map.getSize();
+        var pixelWidth = mapSize.x / 4;
+        var pixelHeight = pixelWidth * (img.height / img.width);
+        var centerPoint = map.latLngToLayerPoint(bounds.getCenter());
+        var nwPoint = centerPoint.subtract([pixelWidth / 2, pixelHeight / 2]);
+        var nePoint = centerPoint.add([pixelWidth / 2, -pixelHeight / 2]);
+        var swPoint = centerPoint.add([-pixelWidth / 2, pixelHeight / 2]);
+        var sePoint = centerPoint.add([pixelWidth / 2, pixelHeight / 2]);
+        var corners = [
+          map.layerPointToLatLng(nwPoint),
+          map.layerPointToLatLng(nePoint),
+          map.layerPointToLatLng(swPoint),
+          map.layerPointToLatLng(sePoint),
+        ];
         overlayLayer = L.distortableImageOverlay(ev.target.result, {
-          corners: [
-            bounds.getNorthWest(),
-            bounds.getNorthEast(),
-            bounds.getSouthWest(),
-            bounds.getSouthEast(),
-          ],
+          corners: corners,
           opacity: parseFloat(document.getElementById('overlay-opacity').value),
+          selected: true,
+          mode: 'drag',
         }).addTo(map);
         overlayScale = 1;
         if (overlaySizeSlider) overlaySizeSlider.value = 1;


### PR DESCRIPTION
## Summary
- compute overlay corners based on image dimensions to keep aspect ratio
- set image overlays to drag mode and selected by default so they can be moved immediately

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c56d510594832e9bd9eac28a226061