### PR TITLE
Guard overlay size slider event listener

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -108,16 +108,18 @@ document.getElementById('overlay-opacity').addEventListener('input', function (e
   }
 });
 
-overlaySizeSlider.addEventListener('input', function (e) {
-  if (overlayLayer) {
-    var scale = parseFloat(e.target.value);
-    var factor = scale / overlayScale;
-    if (overlayLayer.scaleBy) {
-      overlayLayer.scaleBy(factor);
+if (overlaySizeSlider) {
+  overlaySizeSlider.addEventListener('input', function (e) {
+    if (overlayLayer) {
+      var scale = parseFloat(e.target.value);
+      var factor = scale / overlayScale;
+      if (overlayLayer.scaleBy) {
+        overlayLayer.scaleBy(factor);
+      }
+      overlayScale = scale;
     }
-    overlayScale = scale;
-  }
-});
+  });
+}
 
 // Remove default marker shadows
 L.Icon.Default.mergeOptions({


### PR DESCRIPTION
## Summary
- Wrap overlay size slider listener in null check
- Ensure overlay size slider only used when present

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d1516164832e80777c10bbba307b