### PR TITLE
Expand overlay to full map extent

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -12,7 +12,8 @@ var tiles = L.tileLayer('map/{z}/{x}/{y}.jpg', {
   maxZoom: 6,
 }).addTo(map);
 // Overlay extracted from image and used for OCR/template matching
-var overlayBounds = [[-58.003132, 100.0], [-49.5, 120.0]];
+// Use world bounds so the overlay spans the entire map
+var overlayBounds = [[-85, -180], [85, 180]];
 // User-supplied overlay image should be placed at overlays/overlay.png
 L.imageOverlay('overlays/overlay.png', overlayBounds).addTo(map);
 tiles.once('load', function () {

--- a/scripts/extract_overlay.py
+++ b/scripts/extract_overlay.py
@@ -9,8 +9,9 @@ OVERLAY_PATH = 'overlays/overlay.png'
 ICONS_DIR = 'icons'
 FEATURES_CSV = 'data/features.csv'
 # geographic bounds of overlay: [[minLat, minLon], [maxLat, maxLon]]
-MIN_LAT, MIN_LON = -58.003132, 100.0
-MAX_LAT, MAX_LON = -49.5, 120.0
+# Use world bounds so the overlay spans the entire map
+MIN_LAT, MIN_LON = -85, -180
+MAX_LAT, MAX_LON = 85, 180
 
 def pixel_to_latlon(x, y, width, height):
     lon = MIN_LON + (x / width) * (MAX_LON - MIN_LON)


### PR DESCRIPTION
## Summary
- Stretch overlay image across entire map by using world bounds
- Sync extraction script with updated world-bounds configuration

## Testing
- `node --check js/map.js`
- `python -m py_compile scripts/extract_overlay.py`
- `python scripts/extract_overlay.py` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68c759cfb068832ead7bb7d8a3cd22dd