### PR TITLE
Allow text labels to use overlay categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,11 @@
             <label>Curve Radius:
                 <input type="number" id="text-curve-radius" value="0">
             </label>
+            <label>Overlay:
+                <select id="text-overlay">
+                    <option value="">None</option>
+                </select>
+            </label>
             <button id="text-save">Save</button>
             <button id="text-cancel">Cancel</button>
             <button id="text-convert" class="hidden">Convert to Marker</button>


### PR DESCRIPTION
## Summary
- add overlay selection to the text label form
- generalize overlay handling so text labels can join the same overlay groups as markers
- persist text overlay choices when saving, editing, or converting between text and markers

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c89765da10832e9625be20a96027d0