### PR TITLE
Allow closer map zoom levels

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -2,14 +2,16 @@
 var map = L.map('map', {
   zoomAnimation: true,
   markerZoomAnimation: true,
-  attributionControl: false
+  attributionControl: false,
+  maxZoom: 8,
 }).setView([0, 0], 0);
 
 var tiles = L.tileLayer('map/{z}/{x}/{y}.jpg', {
   continuousWorld: false,
   noWrap: true,
   minZoom: 2,
-  maxZoom: 6,
+  maxZoom: 8,
+  maxNativeZoom: 7,
 }).addTo(map);
 // Overlay extracted from image and used for OCR/template matching
 // Use world bounds so the overlay spans the entire map


### PR DESCRIPTION
## Summary
- raise the Leaflet map's maximum zoom level
- extend the tile layer to support digital zoom beyond level 7 so tiles can be viewed closer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8a3762974832eaee34d04332f117e