### PR TITLE
Reduce marker icon sizes by half

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -62,38 +62,38 @@ map.on('click', function () {
   var WigwamIcon = L.icon({
                 iconUrl:       'icons/wigwam.png',
                 iconRetinaUrl: 'icons/wigwam.png',
-                iconSize:    [1.25, 1.25],
-                iconAnchor:  [0.625, 1.25],
-                popupAnchor: [0.125, -1.25],
-                tooltipAnchor: [0.625, -0.625]
+                iconSize:    [0.625, 0.625],
+                iconAnchor:  [0.3125, 0.625],
+                popupAnchor: [0.0625, -0.625],
+                tooltipAnchor: [0.3125, -0.3125]
         });
   var SettlementsIcon = L.icon({
                 iconUrl:       'icons/settlement.png',
                 iconRetinaUrl: 'icons/settlement.png',
 
-                iconSize:    [1.875, 1.875],
-                iconAnchor:  [0.875, 1.875],
-                popupAnchor: [0.125, -1.875],
-                tooltipAnchor: [0.875, -0.875]
+                iconSize:    [0.9375, 0.9375],
+                iconAnchor:  [0.4375, 0.9375],
+                popupAnchor: [0.0625, -0.9375],
+                tooltipAnchor: [0.4375, -0.4375]
 
 
         });
   var CapitalIcon = L.icon({
                 iconUrl:       'icons/capital.png',
                 iconRetinaUrl: 'icons/capital.png',
-                iconSize:    [1.25, 1.25],
-                iconAnchor:  [0.625, 1.25],
-                popupAnchor: [0.125, -1.25],
-                tooltipAnchor: [0.625, -0.625]
+                iconSize:    [0.625, 0.625],
+                iconAnchor:  [0.3125, 0.625],
+                popupAnchor: [0.0625, -0.625],
+                tooltipAnchor: [0.3125, -0.3125]
         });
   // Rock
   var RockIcon = L.icon({
                 iconUrl:       'icons/rock.png',
                 iconRetinaUrl: 'icons/rock.png',
-                iconSize:    [1.25, 1.25],
-                iconAnchor:  [0.625, 1.25],
-                popupAnchor: [0.125, -1.25],
-                tooltipAnchor: [0.625, -0.625]
+                iconSize:    [0.625, 0.625],
+                iconAnchor:  [0.3125, 0.625],
+                popupAnchor: [0.0625, -0.625],
+                tooltipAnchor: [0.3125, -0.3125]
         });
   // Fishing
   var fishingIconPath = 'icons/fish.png';
@@ -101,58 +101,58 @@ map.on('click', function () {
                 iconUrl:       fishingIconPath,
                 iconRetinaUrl: fishingIconPath,
                 // Preserve the original aspect ratio of the fish icon (25x11)
-                iconSize:    [2.84, 1.25],
-                iconAnchor:  [1.42, 1.25],
-                popupAnchor: [0.125, -1.25],
-                tooltipAnchor: [1.42, -0.625]
+                iconSize:    [1.42, 0.625],
+                iconAnchor:  [0.71, 0.625],
+                popupAnchor: [0.0625, -0.625],
+                tooltipAnchor: [0.71, -0.3125]
         });
   var AgricultureIcon = L.icon({
                 iconUrl:       'icons/plantinggrounds.png',
                 iconRetinaUrl: 'icons/plantinggrounds.png',
-                iconSize:    [1.25, 1.25],
-                iconAnchor:  [0.625, 1.25],
-                popupAnchor: [0.125, -1.25],
-                tooltipAnchor: [0.625, -0.625]
+                iconSize:    [0.625, 0.625],
+                iconAnchor:  [0.3125, 0.625],
+                popupAnchor: [0.0625, -0.625],
+                tooltipAnchor: [0.3125, -0.3125]
         });
   var PteroglyphIcon = L.icon({
                 iconUrl:       'icons/petrogliph.png',
                 iconRetinaUrl: 'icons/petrogliph.png',
-                iconSize:    [1.25, 1.25],
-                iconAnchor:  [0.625, 1.25],
-                popupAnchor: [0.125, -1.25],
-                tooltipAnchor: [0.625, -0.625]
+                iconSize:    [0.625, 0.625],
+                iconAnchor:  [0.3125, 0.625],
+                popupAnchor: [0.0625, -0.625],
+                tooltipAnchor: [0.3125, -0.3125]
         });
   var MineIcon = L.icon({
                 iconUrl:       'icons/mine.png',
                 iconRetinaUrl: 'icons/mine.png',
-                iconSize:    [1.25, 1.25],
-                iconAnchor:  [0.625, 1.25],
-                popupAnchor: [0.125, -1.25],
-                tooltipAnchor: [0.625, -0.625]
+                iconSize:    [0.625, 0.625],
+                iconAnchor:  [0.3125, 0.625],
+                popupAnchor: [0.0625, -0.625],
+                tooltipAnchor: [0.3125, -0.3125]
         });
   var FortsIcon = L.icon({
                 iconUrl:       'icons/fort.png',
                 iconRetinaUrl: 'icons/fort.png',
-                iconSize:    [2, 1.25],
-                iconAnchor:  [1, 1.25],
-                popupAnchor: [0.2, -1.25],
-                tooltipAnchor: [1, -0.625]
+                iconSize:    [1, 0.625],
+                iconAnchor:  [0.5, 0.625],
+                popupAnchor: [0.1, -0.625],
+                tooltipAnchor: [0.5, -0.3125]
         });
   var ChambersIcon = L.icon({
                 iconUrl:       'icons/csl.png',
                 iconRetinaUrl: 'icons/csl.png',
-                iconSize:    [1.25, 1.25],
-                iconAnchor:  [0.625, 1.25],
-                popupAnchor: [0.125, -1.25],
-                tooltipAnchor: [0.625, -0.625]
+                iconSize:    [0.625, 0.625],
+                iconAnchor:  [0.3125, 0.625],
+                popupAnchor: [0.0625, -0.625],
+                tooltipAnchor: [0.3125, -0.3125]
         });
   var CampsIcon = L.icon({
                 iconUrl:       'icons/fire.png',
                 iconRetinaUrl: 'icons/fire.png',
-                iconSize:    [1.25, 1.25],
-                iconAnchor:  [0.625, 1.25],
-                popupAnchor: [0.125, -1.25],
-                tooltipAnchor: [0.625, -0.625]
+                iconSize:    [0.625, 0.625],
+                iconAnchor:  [0.3125, 0.625],
+                popupAnchor: [0.0625, -0.625],
+                tooltipAnchor: [0.3125, -0.3125]
         });
 
 


### PR DESCRIPTION
## Summary
- halve the base dimensions for each custom Leaflet icon used on the map
- update corresponding anchor, popup, and tooltip offsets to maintain alignment after the resize

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8b436e690832ea5aece8762a6d1a2