### PR TITLE
Add OCR extraction for overlay labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
             <button id="text-convert" class="hidden">Convert to Marker</button>
         </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js"></script>
     <script src="js/map.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>


### PR DESCRIPTION
## Summary
- load Tesseract.js in the main page so OCR is available
- add an overlay text extraction helper that runs Tesseract on the overlay image and places labels on the map
- trigger label extraction once the overlay image has been added to the map

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8d956edd4832e894588b45ff47e32