### PR TITLE
Add manual overlay OCR workflow with CSV export

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -27,6 +27,18 @@ html, body{
     z-index: 1000;
 }
 
+#run-overlay-ocr {
+    position: absolute;
+    top: 100px;
+    right: 10px;
+    z-index: 1000;
+}
+
+#run-overlay-ocr[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
 
 #info-title,
 #info-description {

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <!-- <h1>map</h1> -->
     <div id="map"></div>
     <button id="save-changes">Save Changes</button>
+    <button id="run-overlay-ocr">Run Overlay OCR</button>
     <div id="mouse-coords"></div>
     <div id="info-panel" class="hidden">
         <button id="close-info" class="close-button">&times;</button>


### PR DESCRIPTION
## Summary
- trigger a local download of features.csv when saving text labels cannot reach the server
- add a Run Overlay OCR button that manually runs OCR, places labels, and exports the compiled features.csv when finished
- style the manual OCR control so it aligns with the existing Save Changes button

## Testing
- not run (not specified)

------
https://chatgpt.com/codex/tasks/task_e_68c8ee351e68832e8125e4b31837e356