### PR TITLE
Adjust default map zoom level

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -4,7 +4,7 @@ var map = L.map('map', {
   markerZoomAnimation: true,
   attributionControl: false,
   maxZoom: 8,
-}).setView([0, 0], 0);
+}).setView([0, 0], 4);
 
 var tiles = L.tileLayer('map/{z}/{x}/{y}.jpg', {
   continuousWorld: false,


### PR DESCRIPTION
## Summary
- increase the initial Leaflet map view to zoom level 4 so the map loads closer by default

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f6f45428832ebecaf4593715d91c