### PR TITLE
Adjust initial map zoom level

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -4,7 +4,7 @@ var map = L.map('map', {
   markerZoomAnimation: true,
   attributionControl: false,
   maxZoom: 8,
-}).setView([0, 0], 2);
+}).setView([0, 0], 4);
 
 var tiles = L.tileLayer('map/{z}/{x}/{y}.jpg', {
   continuousWorld: false,


### PR DESCRIPTION
## Summary
- increase the map's initial zoom level to start two steps closer to the tiles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9f0d469c8832eb8a3f57ac03332b8