### PR TITLE
Reposition Long Island tribe labels near Montaukett

### DIFF
--- a/data/features.csv
+++ b/data/features.csv
@@ -24,38 +24,38 @@ text,-32.416427957931774,87.14843750000001,,,SANSHUWACHU,Brook lodge,1,0,0,0,,,
 text,-30.54,84.4,,,Demo,,1,0,0,0,,,
 text,-43.39704454537894,77.26135253906251,,,Cappoaquit,,2.5,0,0,0,,,Geographical Locations
 text,33.43384701757267,-31.816406250000004,,,Aquinnah Wampanoag,Aquinnah (Gay Head) Wampanoag homelands on Martha's Vineyard.,24,0,0,0,,,Tribes
-text,4.22649296425417,-71.89453125000001,,,Canarsie,Canarsie Lenape homelands in present-day Brooklyn.,24,0,0,0,,,Tribes
-text,31.35657367879881,-77.51953125000001,,,Corchaug,Corchaug territory on the North Fork of Long Island.,24,0,0,0,,,Tribes
+text,-75.63994307116569,-103.87893643630531,,,Canarsie,Canarsie Lenape homelands in present-day Brooklyn.,24,0,0,0,,,Tribes
+text,-76.43994307116569,-104.47893643630530,,,Corchaug,Corchaug territory on the North Fork of Long Island.,24,0,0,0,,,Tribes
 text,43.324625820668444,11.601562500000002,,,Eastern Niantic,Eastern Niantic homelands along the Niantic River in Connecticut.,24,0,0,0,,,Tribes
 text,19.814953196807718,9.667968750000002,,,Eastern Pequot,"Eastern Pequot Tribal Nation homelands near North Stonington, Connecticut.",24,0,0,0,,,Tribes
 text,-1.9196303607310392,32.16796875000001,,,Hammonasset,Hammonasset homelands along the central Connecticut shoreline.,24,0,0,0,,,Tribes
-text,28.925393798175957,-74.00390625000001,,,Manhanset,"Manhanset people of Shelter Island, between Long Island's forks.",24,0,0,0,,,Tribes
+text,-75.93994307116569,-104.67893643630531,,,Manhanset,"Manhanset people of Shelter Island, between Long Island's forks.",24,0,0,0,,,Tribes
 text,25.48783594509412,-72.24609375000001,,,Manissean,Manissean (Manitou) homelands on Block Island.,24,0,0,0,,,Tribes
 text,30.905782944103155,12.656250000000002,,,Massachusett,Massachusett homelands around the Shawmut Peninsula (Boston).,24,0,0,0,,,Tribes
 text,-2.972937596783648,-4.042968750000001,,,Mashantucket Pequot,Mashantucket Pequot homelands near the Pawcatuck River.,24,0,0,0,,,Tribes
 text,-1.0411271920228107,-98.43750000000001,,,Mashpee Wampanoag,Mashpee Wampanoag homelands on Cape Cod.,24,0,0,0,,,Tribes
-text,25.646267907808376,-104.0625,,,Matinecock,Matinecock homelands on Long Island's north shore.,24,0,0,0,,,Tribes
-text,8.243597703535078,-28.828125000000004,,,Merrick,Merrick (Merokee) territory on Long Island's south shore.,24,0,0,0,,,Tribes
+text,-76.13994307116569,-104.02893643630530,,,Matinecock,Matinecock homelands on Long Island's north shore.,24,0,0,0,,,Tribes
+text,-75.53994307116569,-104.12893643630531,,,Merrick,Merrick (Merokee) territory on Long Island's south shore.,24,0,0,0,,,Tribes
 text,-76.08994307116569,-104.2289364363053,,,Montaukett,Montaukett homelands at the eastern tip of Long Island.,24,0,0,0,,,Tribes
 text,35.46248239962616,-51.15234375,,,Mohegan,Mohegan homelands along the Thames River in Connecticut.,24,0,0,0,,,Tribes
 text,23.730567495891073,-49.74609375000001,,,Narragansett,Narragansett homelands along the southern Rhode Island coast.,24,0,0,0,,,Tribes
 text,-7.6956058383808355,130.60546875000003,,,Nauset,Nauset (Cape Cod) Wampanoag homelands on the outer Cape.,24,0,0,0,,,Tribes
 text,15.969740744184557,31.640625000000004,,,Nipmuc,Nipmuc homelands across central Massachusetts and northern Connecticut.,24,0,0,0,,,Tribes
-text,-29.05645588328861,-111.09375000000001,,,Nissequogue,"Nissequogue homelands around present-day Smithtown, Long Island.",24,0,0,0,,,Tribes
+text,-76.33994307116569,-103.77893643630530,,,Nissequogue,"Nissequogue homelands around present-day Smithtown, Long Island.",24,0,0,0,,,Tribes
 text,1.2430650599063902,-34.45312500000001,,,Noepe Wampanoag,Noepe (Nantucket) Wampanoag homelands on Nantucket Island.,24,0,0,0,,,Tribes
 text,-8.043956894460539,-56.25000000000001,,,Paugussett,Paugussett homelands along the lower Housatonic River.,24,0,0,0,,,Tribes
 text,16.644090072111453,-10.371093750000002,,,Pequot,Pequot homelands surrounding the lower Thames River.,24,0,0,0,,,Tribes
 text,-10.989770075191197,-74.88281250000001,,,Podunk,Podunk homelands on the east side of the Connecticut River.,24,0,0,0,,,Tribes
 text,-19.6247252492234,-84.19921875000001,,,Pokanoket,Pokanoket (Wampanoag) homelands around Mount Hope and Narragansett Bay.,24,0,0,0,,,Tribes
 text,25.80471746754988,5.625,,,Quinnipiac,Quinnipiac homelands at the mouth of the Quinnipiac River.,24,0,0,0,,,Tribes
-text,-12.023393741840687,-32.51953125000001,,,Rockaway,Rockaway (Reckgawawank) Lenape homelands on the Rockaway Peninsula.,24,0,0,0,,,Tribes
+text,-75.83994307116569,-104.57893643630530,,,Rockaway,Rockaway (Reckgawawank) Lenape homelands on the Rockaway Peninsula.,24,0,0,0,,,Tribes
 text,-20.94330364995559,-62.75390625000001,,,Schaghticoke,Schaghticoke homelands near the confluence of the Housatonic and Ten Mile Rivers.,24,0,0,0,,,Tribes
-text,39.09643392624887,-43.59375000000001,,,Secatogue,Secatogue homelands around Islip on Long Island.,24,0,0,0,,,Tribes
-text,35.17554453092622,-90.87890625000001,,,Setalcott,Setalcott (Setauket) homelands on Long Island's north shore.,24,0,0,0,,,Tribes
-text,14.783195497235205,-88.06640625000001,,,Shinnecock,Shinnecock homelands near Shinnecock Bay on Long Island.,24,0,0,0,,,Tribes
+text,-76.23994307116570,-104.17893643630531,,,Secatogue,Secatogue homelands around Islip on Long Island.,24,0,0,0,,,Tribes
+text,-76.53994307116569,-103.92893643630531,,,Setalcott,Setalcott (Setauket) homelands on Long Island's north shore.,24,0,0,0,,,Tribes
+text,-76.03994307116569,-104.32893643630530,,,Shinnecock,Shinnecock homelands near Shinnecock Bay on Long Island.,24,0,0,0,,,Tribes
 text,38.411548943933866,-29.707031250000004,,,Tunxis,Tunxis homelands in the Farmington River Valley.,24,0,0,0,,,Tribes
-text,19.4837204911567,-63.10546875000001,,,Unkechaug,Unkechaug (Poospatuck) homelands on Long Island's south shore.,24,0,0,0,,,Tribes
-text,25.010876639571176,-115.83984375000001,,,Unqua,Unqua homelands near present-day Seaford and Massapequa.,24,0,0,0,,,Tribes
+text,-76.38994307116569,-104.37893643630531,,,Unkechaug,Unkechaug (Poospatuck) homelands on Long Island's south shore.,24,0,0,0,,,Tribes
+text,-75.73994307116570,-104.27893643630530,,,Unqua,Unqua homelands near present-day Seaford and Massapequa.,24,0,0,0,,,Tribes
 text,-13.9066645765284,59.23828125000001,,,Wampanoag,Wampanoag homelands across Plymouth and Bristol counties.,24,0,0,0,,,Tribes
 text,33.726695132022485,-28.652343750000004,,,Wangunk,Wangunk homelands along the lower Connecticut River.,24,0,0,0,,,Tribes
 text,31.656222638689336,-103.35937500000001,,,Wappinger,Wappinger homelands spanning southwestern Connecticut and the lower Hudson Valley.,24,0,0,0,,,Tribes


### PR DESCRIPTION
## Summary
- repositioned the Canarsie, Corchaug, Manhanset, Matinecock, Merrick, Nissequogue, Rockaway, Secatogue, Setalcott, Shinnecock, Unkechaug, and Unqua text markers
- clustered those labels around the Montaukett location so they appear together on the map

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb7e41a6b0832eaac809539f8aadbd