### PR TITLE
Limit maximum map zoom to prevent clipping

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -3,15 +3,15 @@ var map = L.map('map', {
   zoomAnimation: true,
   markerZoomAnimation: true,
   attributionControl: false,
-  maxZoom: 8,
+  maxZoom: 6,
 }).setView([0, 0], 4);
 
 var tiles = L.tileLayer('map/{z}/{x}/{y}.jpg', {
   continuousWorld: false,
   noWrap: true,
   minZoom: 2,
-  maxZoom: 8,
-  maxNativeZoom: 7,
+  maxZoom: 6,
+  maxNativeZoom: 6,
 }).addTo(map);
 // Overlay extracted from image and used for OCR/template matching
 // Use world bounds so the overlay spans the entire map


### PR DESCRIPTION
## Summary
- reduce the Leaflet map's maximum zoom level to keep users from zooming past the available tiles
- align the tile layer's maxZoom and maxNativeZoom with the highest provided tile level

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbabca6d4c832ea4e34eb0d2e945ba