### PR TITLE
Adjust forts icon aspect ratio

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -408,13 +408,18 @@ var MineIcon = createScaledIcon({
   tooltipAnchor: [0.9375, -0.9375],
 });
 
+// Preserve the original 39x17 aspect ratio of the fort icon while keeping the
+// consistent marker height used throughout the map.
+var fortIconHeight = 1.875;
+var fortIconWidth = (39 / 17) * fortIconHeight;
+
 var FortsIcon = createScaledIcon({
   iconUrl: 'icons/fort.png',
   iconRetinaUrl: 'icons/fort.png',
-  iconSize: [3, 1.875],
-  iconAnchor: [1.5, 1.875],
-  popupAnchor: [0.3, -1.875],
-  tooltipAnchor: [1.5, -0.9375],
+  iconSize: [fortIconWidth, fortIconHeight],
+  iconAnchor: [fortIconWidth / 2, fortIconHeight],
+  popupAnchor: [0.3, -fortIconHeight],
+  tooltipAnchor: [fortIconWidth / 2, -fortIconHeight / 2],
 });
 
 var ChambersIcon = createScaledIcon({


### PR DESCRIPTION
## Summary
- preserve the original aspect ratio of the fort marker while keeping the shared marker height
- update the fort icon anchors to match the wider marker footprint

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccfd4a33b4832eb303a0327fdeaf3a