### PR TITLE
Ensure marked footnotes load before map

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,8 +108,8 @@
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js"></script>
-    <script src="js/map.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
+    <script src="js/map.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Marked and DOMPurify before the map script so the footnote extension can register immediately
- tighten the placeholder regex and add polling/script-load hooks so the extension attaches as soon as Marked appears

## Testing
- node <<'NODE' (marked footnote rendering)


------
https://chatgpt.com/codex/tasks/task_e_68ce4209fa48832eb42fae7b6ccf9716