### PR TITLE
Add optional marker subheader support

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -44,6 +44,13 @@ html, body{
     text-align: center;
 }
 
+.info-subheader {
+    text-align: center;
+    font-size: 0.95em;
+    margin: 0.25em 0 0.5em;
+    color: #555;
+}
+
 #info-description {
     text-align: left;
 }

--- a/data/features.csv
+++ b/data/features.csv
@@ -1,4 +1,4 @@
-type,lat,lng,icon,name,text,description,size,angle,spacing,curve,coords,style,overlay
+type,lat,lng,icon,name,subheader/text,description,size,angle,spacing,curve,coords,style,overlay
 marker,-30.3731045201212,76.22521225521355,settlement,dsfds,,sdfsdf,,,,,,{},
 marker,-9.583455567389747,46.61127269396798,wigwam,Marker,,,,,,,,{},
 marker,-10.125631403179714,47.83495616956516,settlement,Marker,,,,,,,,{},

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
     <div id="info-panel" class="hidden">
         <button id="close-info" class="close-button">&times;</button>
         <h2 id="info-title"></h2>
+        <h3 id="info-subheader" class="info-subheader hidden"></h3>
         <div id="info-description"></div>
     </div>
     <div id="marker-form-overlay" class="hidden">
@@ -28,6 +29,9 @@
             <h3>Add Marker</h3>
             <label>Name:
                 <input type="text" id="marker-name">
+            </label>
+            <label>Subheader:
+                <input type="text" id="marker-subheader">
             </label>
             <label>Description:
                 <small>Supports Markdown (e.g., <code>**bold**</code>, <code>![alt](url)</code> for images) and footnotes (pair <code>[^1]</code> with <code>[^1]: Source details</code>).</small>


### PR DESCRIPTION
## Summary
- add a marker subheader field to the info panel and marker form so notes can appear between titles and descriptions
- persist subheader values when loading, saving, converting, and copying markers so the info panel always reflects the latest data
- style the info panel subheader to match the panel’s layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0df96ad50832e8c6709b18a443988