### PR TITLE
Keep text labels anchored while zooming

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -116,18 +116,26 @@ html, body{
 /* Style for text markers */
 .text-label {
     position: absolute;
-    transform: translate(-50%, -50%);
+}
+.text-label__inner {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    transform-origin: top center;
     text-align: center;
 }
-.text-label span {
+.text-label__inner span {
     font-family: 'Roboto', 'Open Sans', 'Helvetica Neue', Arial, sans-serif;
     font-weight: bold;
     color: #333;
     display: inline-block;
     letter-spacing: 0;
+    transform-origin: top center;
 }
-.text-label svg {
+.text-label__inner svg {
     overflow: visible;
+    transform-origin: top center;
 }
 
 /* Marker form styles */

--- a/js/map.js
+++ b/js/map.js
@@ -1517,20 +1517,23 @@ function addTextLabelToMap(data) {
       '">' +
       data.text +
       '</textPath></text></svg>';
-    textIcon = L.divIcon({ className: 'text-label', html: svgHtml, iconAnchor: [0, 0] });
+    var curvedHtml = '<div class="text-label__inner">' + svgHtml + '</div>';
+    textIcon = L.divIcon({ className: 'text-label', html: curvedHtml, iconAnchor: [0, 0] });
   } else {
+    var spanHtml =
+      '<span style="font-size:' +
+      data.size +
+      'px; letter-spacing:' +
+      data.spacing +
+      'px; transform: rotate(' +
+      (data.angle || 0) +
+      'deg);">' +
+      data.text +
+      '</span>';
+    var straightHtml = '<div class="text-label__inner">' + spanHtml + '</div>';
     textIcon = L.divIcon({
       className: 'text-label',
-      html:
-        '<span style="font-size:' +
-        data.size +
-        'px; letter-spacing:' +
-        data.spacing +
-        'px; transform: rotate(' +
-        (data.angle || 0) +
-        'deg);">' +
-        data.text +
-        '</span>',
+      html: straightHtml,
       iconAnchor: [0, 0],
     });
   }
@@ -2042,20 +2045,23 @@ function editTextForm(labelMarker) {
         '">' +
         text +
         '</textPath></text></svg>';
-      textIcon = L.divIcon({ className: 'text-label', html: svgHtml, iconAnchor: [0, 0] });
+      var curvedHtml = '<div class="text-label__inner">' + svgHtml + '</div>';
+      textIcon = L.divIcon({ className: 'text-label', html: curvedHtml, iconAnchor: [0, 0] });
     } else {
+      var spanHtml =
+        '<span style="font-size:' +
+        size +
+        'px; letter-spacing:' +
+        spacing +
+        'px; transform: rotate(' +
+        angle +
+        'deg);">' +
+        text +
+        '</span>';
+      var straightHtml = '<div class="text-label__inner">' + spanHtml + '</div>';
       textIcon = L.divIcon({
         className: 'text-label',
-        html:
-          '<span style="font-size:' +
-          size +
-          'px; letter-spacing:' +
-          spacing +
-          'px; transform: rotate(' +
-          angle +
-          'deg);">' +
-          text +
-          '</span>',
+        html: straightHtml,
         iconAnchor: [0, 0],
       });
     }


### PR DESCRIPTION
## Summary
- wrap text label markup in an inner container so zoom scaling keeps the top of the label fixed to the marker
- update text label transform origins so rotations still pivot around the anchored top edge

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d2385c76b8832e9129e2655b6c4db4