### PR TITLE
Fix text label positioning when zooming

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -117,13 +117,16 @@ html, body{
 .text-label {
     position: absolute;
 
+    width: auto !important;
+    height: auto !important;
     text-align: center;
 }
 .text-label__inner span {
     font-family: 'Roboto', 'Open Sans', 'Helvetica Neue', Arial, sans-serif;
     font-weight: bold;
     color: #333;
-    display: inline-block;
+    display: block;
+    line-height: 1;
     letter-spacing: 0;
     transform-origin: top center;
 }


### PR DESCRIPTION
## Summary
- allow text label markers to size themselves with their content so the draggable hit area follows zoom scaling
- set text label spans to block elements with unit line height so their top edge stays anchored when zooming out

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4bf33a3d8832e9e8c58382efc78aa