### PR TITLE
Allow local images in marker descriptions

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -602,8 +602,8 @@ function showInfo(title, subheader, description) {
     }
   }
   var sanitizeConfig = {
-    ADD_TAGS: ['section', 'sup', 'ol', 'li', 'a'],
-    ADD_ATTR: ['id', 'href'],
+    ADD_TAGS: ['section', 'sup', 'ol', 'li', 'a', 'img'],
+    ADD_ATTR: ['id', 'href', 'src', 'alt', 'title'],
   };
   var html = rendered;
   if (typeof DOMPurify !== 'undefined' && DOMPurify && typeof DOMPurify.sanitize === 'function') {


### PR DESCRIPTION
## Summary
- allow sanitized marker descriptions to retain Markdown image tags by whitelisting <img>
- permit common image attributes so local files in the images folder render in the info panel

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df717f7478832e8d07b07c8e34b63d