### PR TITLE
Fix curved text radius measurement

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -121,7 +121,8 @@ html, body{
     height: auto !important;
     text-align: center;
 }
-.text-label__inner span {
+.text-label__inner span,
+.text-label__measure {
     font-family: 'Roboto', 'Open Sans', 'Helvetica Neue', Arial, sans-serif;
     font-weight: bold;
     color: #333;
@@ -129,6 +130,13 @@ html, body{
     line-height: 1;
     letter-spacing: 0;
     transform-origin: top center;
+}
+
+.text-label__measure {
+    position: absolute;
+    visibility: hidden;
+    white-space: pre;
+    pointer-events: none;
 }
 .text-label__inner svg {
     overflow: visible;

--- a/js/map.js
+++ b/js/map.js
@@ -1517,6 +1517,35 @@ function addMarkerToMap(data) {
   return customMarker;
 }
 
+function measureCurvedTextWidth(text, fontSize, letterSpacing) {
+  if (!text) {
+    return 0;
+  }
+  var span = document.createElement('span');
+  span.className = 'text-label__measure';
+  var sizeValue = parseFloat(fontSize);
+  if (!Number.isFinite(sizeValue)) {
+    sizeValue = 0;
+  }
+  var spacingValue = parseFloat(letterSpacing);
+  if (!Number.isFinite(spacingValue)) {
+    spacingValue = 0;
+  }
+  span.style.position = 'absolute';
+  span.style.visibility = 'hidden';
+  span.style.pointerEvents = 'none';
+  span.style.whiteSpace = 'pre';
+  span.style.fontSize = sizeValue + 'px';
+  span.style.letterSpacing = spacingValue + 'px';
+  span.style.left = '-9999px';
+  span.style.top = '-9999px';
+  span.textContent = text;
+  document.body.appendChild(span);
+  var width = span.getBoundingClientRect().width;
+  document.body.removeChild(span);
+  return width;
+}
+
 function addTextLabelToMap(data) {
   if (data.subheader === undefined || data.subheader === null) {
     data.subheader = '';
@@ -1525,15 +1554,7 @@ function addTextLabelToMap(data) {
   var textIcon;
   var pathWidth = 0;
   if (data.curve) {
-    var tempSpan = document.createElement('span');
-    tempSpan.style.fontSize = data.size + 'px';
-    tempSpan.style.letterSpacing = data.spacing + 'px';
-    tempSpan.style.whiteSpace = 'pre';
-    tempSpan.style.visibility = 'hidden';
-    tempSpan.textContent = data.text;
-    document.body.appendChild(tempSpan);
-    pathWidth = tempSpan.getBoundingClientRect().width;
-    document.body.removeChild(tempSpan);
+    pathWidth = measureCurvedTextWidth(data.text, data.size, data.spacing);
     var r = Math.abs(data.curve);
     var sweep = data.curve > 0 ? 0 : 1;
     var pathId = 'text-curve-' + Date.now() + Math.random().toString(36).slice(2);
@@ -2053,15 +2074,7 @@ function editTextForm(labelMarker) {
     var textIcon;
     var pathWidth = 0;
     if (curve) {
-      var tempSpan = document.createElement('span');
-      tempSpan.style.fontSize = size + 'px';
-      tempSpan.style.letterSpacing = spacing + 'px';
-      tempSpan.style.whiteSpace = 'pre';
-      tempSpan.style.visibility = 'hidden';
-      tempSpan.textContent = text;
-      document.body.appendChild(tempSpan);
-      pathWidth = tempSpan.getBoundingClientRect().width;
-      document.body.removeChild(tempSpan);
+      pathWidth = measureCurvedTextWidth(text, size, spacing);
       var r = Math.abs(curve);
       var sweep = curve > 0 ? 0 : 1;
       var pathId = 'text-curve-' + Date.now() + Math.random().toString(36).slice(2);


### PR DESCRIPTION
## Summary
- ensure curved text measurement uses the same font properties as rendered labels so the arc radius matches the text width
- refactor curved text handling to share a helper for measuring path width across add and edit flows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e303798924832eb322871eb3ae0684