### PR TITLE
Limit text label interactions to visible glyphs

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -120,6 +120,10 @@ html, body{
     width: auto !important;
     height: auto !important;
     text-align: center;
+    pointer-events: none;
+}
+.text-label__inner {
+    pointer-events: none;
 }
 .text-label__inner span,
 .text-label__measure {
@@ -132,6 +136,13 @@ html, body{
     transform-origin: top center;
 }
 
+.text-label__inner span,
+.text-label__inner svg text,
+.text-label__inner svg textPath,
+.text-label__inner svg tspan {
+    pointer-events: auto;
+}
+
 .text-label__measure {
     position: absolute;
     visibility: hidden;
@@ -141,6 +152,7 @@ html, body{
 .text-label__inner svg {
     overflow: visible;
     transform-origin: top center;
+    pointer-events: none;
 }
 
 /* Marker form styles */


### PR DESCRIPTION
## Summary
- prevent text label containers from capturing pointer events so only glyphs respond
- allow curved text markers to be clicked and dragged only when hovering over the rendered text

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e331bc4048832eb4fe214261a0b8ba