### PR TITLE
Remove Run Overlay OCR button and related code

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -27,18 +27,6 @@ html, body{
     z-index: 1000;
 }
 
-#run-overlay-ocr {
-    position: absolute;
-    top: 100px;
-    right: 10px;
-    z-index: 1000;
-}
-
-#run-overlay-ocr[disabled] {
-    opacity: 0.6;
-    cursor: not-allowed;
-}
-
 .floating-button {
     background: #1f3c88;
     color: #fff;

--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
 
     <div id="map"></div>
     <button id="save-changes">Save Changes</button>
-    <button id="run-overlay-ocr">Run Overlay OCR</button>
     <button
         id="credits-toggle"
         class="floating-button"

--- a/js/map.js
+++ b/js/map.js
@@ -2342,13 +2342,6 @@ map.on(L.Draw.Event.DELETED, function (e) {
   updateEditToolbar();
 });
 
-var runOverlayOcrButton = document.getElementById('run-overlay-ocr');
-if (runOverlayOcrButton) {
-  runOverlayOcrButton.addEventListener('click', function () {
-    runOverlayOcrAndDownload();
-  });
-}
-
 document.getElementById('save-changes').addEventListener('click', function () {
   exportFeaturesToCSV();
 });


### PR DESCRIPTION
## Summary
- remove the obsolete Run Overlay OCR control from the map page
- delete the unused styling block that positioned the Run Overlay OCR button
- remove the JavaScript event hook that invoked the Run Overlay OCR command

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e353619d24832eb57d24df217de6d2