### PR TITLE
Fix curved text label hit area sizing

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -1569,8 +1569,18 @@ function addTextLabelToMap(data) {
     var sweep = data.curve > 0 ? 0 : 1;
     var pathId = 'text-curve-' + Date.now() + Math.random().toString(36).slice(2);
     var d = 'M0,0 A' + r + ',' + r + ' 0 0,' + sweep + ' ' + pathWidth + ',0';
+    var fontSizeValue = parseFloat(data.size);
+    if (!Number.isFinite(fontSizeValue) || fontSizeValue <= 0) {
+      fontSizeValue = 1;
+    }
+    var svgWidth = Math.max(pathWidth, 1);
+    var svgHeight = Math.max(fontSizeValue, 1);
     var svgHtml =
-      '<svg xmlns="http://www.w3.org/2000/svg" style="transform: rotate(' +
+      '<svg xmlns="http://www.w3.org/2000/svg" width="' +
+      svgWidth +
+      '" height="' +
+      svgHeight +
+      '" style="overflow: visible; transform: rotate(' +
       (data.angle || 0) +
       'deg);"><path id="' +
       pathId +


### PR DESCRIPTION
## Summary
- restrict curved text label SVG dimensions to the measured text width and font height so the draggable hit area matches the rendered text

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e3558633d0832ea7bd6a095bb55e23