### PR TITLE
Scale text label wrapper to maintain curved alignment

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -210,6 +210,7 @@ html, body{
 }
 .text-label__inner {
     pointer-events: none;
+    transform-origin: top left;
 }
 .text-label__inner span,
 .text-label__measure {

--- a/js/map.js
+++ b/js/map.js
@@ -1046,29 +1046,12 @@ function rescaleTextLabels() {
   var scale = Math.pow(2, map.getZoom() - baseZoom);
   allTextLabels.forEach(function (m) {
     if (m._icon) {
-      var span = m._icon.querySelector('span');
-      if (span) {
-        span.style.fontSize = m._baseFontSize * scale + 'px';
-        span.style.letterSpacing = (m._baseLetterSpacing || 0) * scale + 'px';
-      } else {
-        var svg = m._icon.querySelector('svg');
-        if (svg) {
-          var text = svg.querySelector('text');
-          if (text) {
-            text.style.fontSize = m._baseFontSize * scale + 'px';
-            text.style.letterSpacing = (m._baseLetterSpacing || 0) * scale + 'px';
-          }
-          if (m._baseCurve) {
-            var path = svg.querySelector('path');
-            if (path) {
-              var width = (m._basePathWidth || 0) * scale;
-              var r = Math.abs(m._baseCurve) * scale;
-              var sweep = m._baseCurve > 0 ? 0 : 1;
-              path.setAttribute('d', 'M0,0 A' + r + ',' + r + ' 0 0,' + sweep + ' ' + width + ',0');
-            }
-          }
-        }
+      var inner = m._icon.querySelector('.text-label__inner');
+      if (!inner) {
+        return;
       }
+      inner.style.transformOrigin = 'top left';
+      inner.style.transform = 'scale(' + scale + ')';
     }
   });
 }
@@ -1669,10 +1652,6 @@ function addTextLabelToMap(data) {
   data.overlay = overlayName;
   m._baseFontSize = data.size;
   m._baseLetterSpacing = data.spacing;
-  if (data.curve) {
-    m._baseCurve = data.curve;
-    m._basePathWidth = pathWidth;
-  }
   m._data = data;
   m._markerType = 'text';
   allTextLabels.push(m);
@@ -2166,13 +2145,6 @@ function editTextForm(labelMarker) {
     labelMarker.setIcon(textIcon);
     labelMarker._baseFontSize = size;
     labelMarker._baseLetterSpacing = spacing;
-    if (curve) {
-      labelMarker._baseCurve = curve;
-      labelMarker._basePathWidth = pathWidth;
-    } else {
-      delete labelMarker._baseCurve;
-      delete labelMarker._basePathWidth;
-    }
     data.text = text;
     data.subheader = subheader;
     data.description = description;


### PR DESCRIPTION
## Summary
- scale the text label wrapper element during zoom instead of mutating font and path geometry
- remove unused bookkeeping from curved text creation and editing for cleaner state
- set the wrapper's transform origin so curved labels stay anchored when the map zoom changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e434352784832eb8170c6c72f4634a